### PR TITLE
dto 形式整理

### DIFF
--- a/backend/golang/src/internal/dbase/user_query_repo.go
+++ b/backend/golang/src/internal/dbase/user_query_repo.go
@@ -3,6 +3,7 @@ package dbase
 import (
 	"context"
 	"fmt"
+	"gymlink/internal/dto"
 	"gymlink/internal/entity"
 	"log"
 
@@ -17,11 +18,6 @@ type checkFollowTypeDTO struct {
 
 type userQueryRepo struct {
 	db *sqlx.DB
-}
-
-type userTypeDTO struct {
-	Id   int64  `db:"followed_id"`
-	Name string `db:"name"`
 }
 
 func NewUserQueryRepo(db *sqlx.DB) *userQueryRepo {
@@ -63,7 +59,7 @@ func (r *userQueryRepo) CheckFollowById(ctx context.Context, followId int64, uid
 
 func (r *userQueryRepo) GetFollowingById(ctx context.Context, userId int64) ([]entity.UserType, error) {
 
-	followingUsersRaw := []userTypeDTO{}
+	followingUsersRaw := []dto.UserDBType{}
 	sql := `SELECT followed_id,users.name 
 			FROM follows 
 			INNER JOIN users ON users.id = followed_id 

--- a/backend/golang/src/internal/dto/user.go
+++ b/backend/golang/src/internal/dto/user.go
@@ -1,6 +1,11 @@
 package dto
 
-type UserType struct {
+type UserDBType struct {
+	Id   int64  `db:"followed_id"`
+	Name string `db:"name"`
+}
+
+type UserJsonType struct {
 	Id   int64  `json:"id"`
 	Name string `json:"name"`
 }

--- a/backend/golang/src/internal/handler/users.go
+++ b/backend/golang/src/internal/handler/users.go
@@ -63,7 +63,7 @@ func (h *UserHandler) LoginUser(ctx *gin.Context) {
 		return
 	}
 
-	user := dto.UserType{
+	user := dto.UserJsonType{
 		Id:   userRaw.Id,
 		Name: userRaw.Name,
 	}
@@ -138,11 +138,19 @@ func (h *UserHandler) GetFollowing(ctx *gin.Context) {
 	if err != nil || id <= 0 {
 		log.Println("error: invalid user")
 	}
-	followingUsers, err := h.svc.GetFollowingById(ctx, id)
+	followingUsersRaw, err := h.svc.GetFollowingById(ctx, id)
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "server internal error"})
 		return
 
+	}
+
+	followingUsers := []dto.UserJsonType{}
+	for _, user := range followingUsersRaw {
+		followingUsers = append(followingUsers, dto.UserJsonType{
+			Id:   user.Id,
+			Name: user.Name,
+		})
 	}
 	ctx.JSON(http.StatusOK, followingUsers)
 }


### PR DESCRIPTION
## やったこと
follower を取得する際にフロントエンド側のオブジェクトアクセス名が id ではなく Id, name ではなく Name でないとアクセスできない形式になっていたので，id, name でアクセスできるように修正した

## 動作検証
開発環境で動作確認済み